### PR TITLE
Update portfolio content and professional positioning

### DIFF
--- a/src/components/cta.astro
+++ b/src/components/cta.astro
@@ -6,8 +6,8 @@ import Link from "./ui/link.astro";
   class="bg-black p-8 md:px-20 md:py-20 mt-20 mx-auto max-w-5xl rounded-lg flex flex-col items-center text-center">
   <h2 class="text-white text-4xl md:text-6xl tracking-tight">Get in touch</h2>
   <p class="text-slate-400 mt-4 text-lg md:text-xl">
-    From event-driven microservices to full-stack web applications, be it
-    mentoring, coaching, or building - I can help.
+    From event-driven microservices to full-stack web applications, AI tooling
+    adoption to developer mentoring - I can help.
   </p>
   <div class="flex mt-5">
     <Link href="/contact" style="inverted">Contact me</Link>

--- a/src/components/features.astro
+++ b/src/components/features.astro
@@ -6,38 +6,38 @@ const features = [
   {
     title: "Full stack web applications",
     description:
-      "I build applications with Elixir, Scala, TypeScript, React, or Astro - using the right tool for the job",
+      "I build applications with Elixir/Phoenix, TypeScript, React, and NextJS - using the right tool for the job",
     icon: "bx:bxs-briefcase",
   },
   {
-    title: "Event driven microservices",
+    title: "Event driven architecture",
     description:
-      "Using RabbitMQ or Kafka to build event driven microservices that scale",
+      "Using RabbitMQ or Kafka to build event driven microservices and scalable systems",
     icon: "bx:bxs-window-alt",
   },
   {
-    title: "Data engineering",
+    title: "AI-supported development",
     description:
-      "Experienced with Apache Spark, having worked with some of the largest healthcare datasets",
-    icon: "bx:bxs-data",
+      "Pioneering AI tooling adoption with Cursor IDE and Devin, driving measurable productivity gains across engineering teams",
+    icon: "bx:bxs-bot",
+  },
+  {
+    title: "Cloud infrastructure",
+    description:
+      "Deploying and operating systems on AWS with Docker, Kubernetes, and CI/CD pipelines",
+    icon: "bx:bxs-cloud",
   },
   {
     title: "Coaching and Mentoring",
     description:
-      "From junior developers to aspiring technology leaders I help people to reach their potential",
+      "From junior developers to aspiring technology leaders, I help people reach their potential through pair programming, training, and mentorship",
     icon: "bx:bxs-user",
   },
   {
-    title: "Product focussed",
+    title: "Developer experience",
     description:
-      "I focus on projects that will bring a positive impact to the world",
-    icon: "bx:bxs-file-find",
-  },
-  {
-    title: "Always learning",
-    description:
-      "Where I don't have the skills I pick up new expertise quickly",
-    icon: "bx:bxs-book-open",
+      "Improving developer productivity through better tooling, events libraries, faster compile times, and developer onboarding",
+    icon: "bx:bxs-rocket",
   },
 ];
 ---
@@ -47,9 +47,9 @@ const features = [
     A deep skill set
   </h2>
   <p class="text-lg mt-4 text-slate-600">
-    With over 10 years of experience as a developer, from individual
-    contributor, to head of engineering, I have the skills to make a big impact
-    in a range of roles.
+    With over 13 years of experience as a developer, from individual contributor
+    to staff engineer, I have the breadth and depth to make a big impact across
+    engineering, product, and people.
   </p>
 </div>
 

--- a/src/components/features.astro
+++ b/src/components/features.astro
@@ -18,7 +18,7 @@ const features = [
   {
     title: "AI-supported development",
     description:
-      "Pioneering AI tooling adoption with Cursor IDE and Devin, driving measurable productivity gains across engineering teams",
+      "Pioneering AI tooling adoption with Claude Code, Cursor IDE, and Devin. Created cross-agent AI Skills to help teams get better results, and mentored engineers in AI-assisted development workflows",
     icon: "bx:bxs-bot",
   },
   {

--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -24,7 +24,7 @@ import { Icon } from "astro-icon";
       Tim Gent
     </h1>
     <p class="text-lg mt-4 text-slate-600 max-w-xl">
-      An experienced software engineer and technical leader
+      Senior to Staff software engineer with a breadth of skills across full stack development, cloud infrastructure, data engineering, AI tooling, and team leadership
     </p>
     <div class="mt-6 flex flex-col sm:flex-row gap-3">
       <Link

--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -24,7 +24,7 @@ import { Icon } from "astro-icon";
       Tim Gent
     </h1>
     <p class="text-lg mt-4 text-slate-600 max-w-xl">
-      Senior to Staff software engineer with a breadth of skills across full stack development, cloud infrastructure, data engineering, AI tooling, and team leadership
+      Staff software engineer at gizmo.ai, with a breadth of skills across full stack development, cloud infrastructure, AI tooling, and team leadership
     </p>
     <div class="mt-6 flex flex-col sm:flex-row gap-3">
       <Link

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -33,7 +33,7 @@ const makeTitle = title
     <!-- <link rel="preload" as="image" href={src} alt="Hero" /> -->
     <SEO
       title={makeTitle}
-      description="Tim Gent - an experienced software engineer and technical leader"
+      description="Tim Gent - Senior to Staff software engineer specialising in Elixir, TypeScript, AI tooling, and technical leadership"
       canonical={canonicalURL}
       twitter={{
         creator: "@timgent",
@@ -44,7 +44,7 @@ const makeTitle = title
         basic: {
           url: canonicalURL,
           type: "website",
-          title: `Tim Gent - an experienced software engineer and technical leader`,
+          title: `Tim Gent - Senior to Staff software engineer specialising in Elixir, TypeScript, AI tooling, and technical leadership`,
           image: resolvedImageWithDomain,
         },
         image: {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -33,7 +33,7 @@ const makeTitle = title
     <!-- <link rel="preload" as="image" href={src} alt="Hero" /> -->
     <SEO
       title={makeTitle}
-      description="Tim Gent - Senior to Staff software engineer specialising in Elixir, TypeScript, AI tooling, and technical leadership"
+      description="Tim Gent - Staff software engineer at gizmo.ai, specialising in Elixir, TypeScript, AI tooling, and technical leadership"
       canonical={canonicalURL}
       twitter={{
         creator: "@timgent",
@@ -44,7 +44,7 @@ const makeTitle = title
         basic: {
           url: canonicalURL,
           type: "website",
-          title: `Tim Gent - Senior to Staff software engineer specialising in Elixir, TypeScript, AI tooling, and technical leadership`,
+          title: `Tim Gent - Staff software engineer at gizmo.ai, specialising in Elixir, TypeScript, AI tooling, and technical leadership`,
           image: resolvedImageWithDomain,
         },
         image: {


### PR DESCRIPTION
## Summary
Updated portfolio website content to reflect current professional experience, skills, and positioning as a Staff software engineer at gizmo.ai.

## Key Changes

- **Skills section**: Refreshed featured skills to highlight current expertise:
  - Replaced "Data engineering" with "AI-supported development" (Cursor IDE, Devin adoption)
  - Replaced "Product focussed" with "Cloud infrastructure" (AWS, Docker, Kubernetes, CI/CD)
  - Replaced "Always learning" with "Developer experience" (tooling, libraries, compile times, onboarding)
  - Updated "Full stack web applications" to emphasize Elixir/Phoenix, TypeScript, React, and NextJS
  - Refined "Event driven microservices" to "Event driven architecture"
  - Enhanced "Coaching and Mentoring" description with specific methodologies

- **Experience summary**: Updated from "over 10 years" to "over 13 years" and changed career progression from "head of engineering" to "staff engineer" with broader impact scope

- **Hero section**: Updated tagline to "Staff software engineer at gizmo.ai, with a breadth of skills across full stack development, cloud infrastructure, AI tooling, and team leadership"

- **CTA section**: Refined messaging to include "AI tooling adoption" alongside existing services

- **SEO metadata**: Updated page title and description to include current role at gizmo.ai and key specializations (Elixir, TypeScript, AI tooling, technical leadership)

## Implementation Details
All changes are content-only updates to Astro components with no structural or styling modifications. The updates maintain consistency across hero, features, CTA, and layout components while presenting a cohesive professional narrative.

https://claude.ai/code/session_01VhiQoT6iSMjHSh8dxL9tCh