### PR TITLE
Fix apps page tab title

### DIFF
--- a/src/pages/apps.astro
+++ b/src/pages/apps.astro
@@ -8,7 +8,7 @@ import { Icon } from "astro-icon";
 const email = "contact.tim.gent@gmail.com";
 ---
 
-<Layout title="Contact">
+<Layout title="My Apps">
   <Container>
     <Sectionhead>
       <Fragment slot="title">My Apps</Fragment>


### PR DESCRIPTION
## Summary

- Fixed incorrect tab title on the Apps page — it was set to `"Contact"` instead of `"My Apps"`