### PR TITLE
Optimize blog images with local asset resolution

### DIFF
--- a/src/content/blog/2018-09-05-spark-scala-serialisation-part-1.md
+++ b/src/content/blog/2018-09-05-spark-scala-serialisation-part-1.md
@@ -2,7 +2,7 @@
 draft: false
 title: "Serialisation challenges with Spark and Scala"
 snippet: ""
-image: { src: "https://images.unsplash.com/photo-1555949963-ff9fe0c870eb?&fit=crop&w=430&h=240", alt: "Scala and Spark code" }
+image: { src: "../../assets/scala-spark-1.webp", alt: "Scala and Spark code" }
 publishDate: "2018-09-05 12:00"
 category: "Technology"
 author: "Tim Gent"

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,9 +1,28 @@
 ---
 import { getCollection } from "astro:content";
 import { Picture } from "astro:assets";
+import type { ImageMetadata } from "astro";
 import Layout from "@layouts/Layout.astro";
 import Container from "@components/container.astro";
 import Sectionhead from "@components/sectionhead.astro";
+
+// Eagerly import all local blog images so Astro can optimise them.
+// Keys are paths relative to this file (src/pages/), e.g. "../assets/foo.webp".
+const localAssets = import.meta.glob<{ default: ImageMetadata }>(
+  "../assets/**/*.{png,jpg,jpeg,gif,webp,avif,svg}",
+  { eager: true }
+);
+
+// Resolve a frontmatter `image.src` value to either an ImageMetadata object
+// (for local assets referenced relative to the content file) or a plain URL
+// string (for remote images).  Content files live in src/content/blog/, so a
+// path like "../../assets/foo.webp" maps to src/assets/foo.webp which is
+// "../assets/foo.webp" relative to this pages file.
+function resolveImage(src: string): ImageMetadata | string {
+  if (src.startsWith("http://") || src.startsWith("https://")) return src;
+  const filename = src.split("/").pop()!;
+  return localAssets[`../assets/${filename}`]?.default ?? src;
+}
 
 // Filter blog entries with 'draft: false' & date before current date
 const publishedBlogEntries = await getCollection("blog", ({ data }) => {
@@ -30,7 +49,7 @@ publishedBlogEntries.sort(function (a, b) {
               <a href={`/blog/${blogPostEntry.id}`}>
                 <div class="grid md:grid-cols-2 gap-5 md:gap-10 items-center">
                   <Picture
-                    src={blogPostEntry.data.image.src}
+                    src={resolveImage(blogPostEntry.data.image.src)}
                     alt={blogPostEntry.data.image.alt}
                     sizes="(max-width: 800px) 100vw, 800px"
                     width={800}


### PR DESCRIPTION
## Summary
This PR implements local image asset optimization for blog posts by eagerly importing local images and resolving image paths at build time. This allows Astro to properly optimize local images while maintaining support for remote image URLs.

## Key Changes
- Added eager glob import of local assets from `src/assets/` directory to enable Astro's image optimization pipeline
- Implemented `resolveImage()` function to intelligently resolve image paths:
  - Returns remote URLs unchanged (http/https)
  - Maps relative paths from content files to local ImageMetadata objects for optimization
  - Falls back to original path if local asset not found
- Updated blog template to use `resolveImage()` when passing image sources to the `Picture` component
- Migrated example blog post image from remote Unsplash URL to local asset (`../../assets/scala-spark-1.webp`)

## Implementation Details
The solution handles the path resolution complexity where content files live in `src/content/blog/` but assets are in `src/assets/`. The function normalizes relative paths by extracting the filename and looking it up in the eagerly-imported assets map, which uses paths relative to the pages file (`src/pages/`).

https://claude.ai/code/session_01Hv9y3mGr9HGn61BmisZiFZ