### PR TITLE
Rename Apps page to Projects and add data-flare library

### DIFF
--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -21,8 +21,8 @@ const menuitems: MenuItem[] = [
     path: "/contact",
   },
   {
-    title: "Apps",
-    path: "/apps"
+    title: "Projects",
+    path: "/projects"
   },
 ];
 ---

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,18 +1,14 @@
 ---
-import Contactform from "@components/contactform.astro";
 import Container from "@components/container.astro";
 import Sectionhead from "@components/sectionhead.astro";
 import Layout from "@layouts/Layout.astro";
-import { Icon } from "astro-icon/components";
-
-const email = "contact.tim.gent@gmail.com";
 ---
 
-<Layout title="My Apps">
+<Layout title="My Projects">
   <Container>
     <Sectionhead>
-      <Fragment slot="title">My Apps</Fragment>
-      <Fragment slot="desc">Applications built by me for use by you</Fragment>
+      <Fragment slot="title">My Projects</Fragment>
+      <Fragment slot="desc">Apps, libraries, and tools built by me</Fragment>
     </Sectionhead>
 
     <ul class="flex flex-wrap m-5 gap-4">
@@ -22,6 +18,19 @@ const email = "contact.tim.gent@gmail.com";
           <p class="text-sm mt-1">Answer a few questions about your holiday and get a perfect packing list generated</p>
           <p class="text-xs text-indigo-500 mt-3 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-200">Visit app →</p>
         </a>
+      </li>
+      <li class="w-full sm:w-1/2 md:w-1/3">
+        <div class="block bg-gray-100 rounded-md p-5 h-full">
+          <div class="flex items-start justify-between gap-2">
+            <p class="font-bold text-lg">data-flare</p>
+            <span class="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full whitespace-nowrap mt-1">Not actively maintained</span>
+          </div>
+          <p class="text-sm mt-1">A Scala library for data quality testing — define checks on your Spark datasets and get clear, actionable results.</p>
+          <div class="flex gap-3 mt-3">
+            <a href="https://tim-gent.com/data-flare" class="text-xs text-indigo-500 hover:text-indigo-700 transition-colors duration-200">Docs →</a>
+            <a href="https://github.com/timgent/data-flare" class="text-xs text-indigo-500 hover:text-indigo-700 transition-colors duration-200">GitHub →</a>
+          </div>
+        </div>
       </li>
     </ul>
   </Container>


### PR DESCRIPTION
## Summary
Renamed the "Apps" page to "Projects" to better reflect the broader scope of content, and added a new project entry for the data-flare Scala library.

## Key Changes
- Renamed `/apps` route to `/projects` throughout the site
- Updated page title and section heading from "My Apps" to "My Projects"
- Updated section description to "Apps, libraries, and tools built by me" to reflect expanded scope
- Removed unused imports: `Contactform`, `Icon`, and the `email` constant
- Added new project card for **data-flare**: a Scala library for data quality testing on Spark datasets
  - Marked as "Not actively maintained" with a visual badge
  - Includes links to documentation and GitHub repository
- Updated navigation menu to reflect the new "Projects" label and path

## Implementation Details
- The data-flare project card follows the existing design pattern with hover effects and responsive layout
- The "Not actively maintained" badge uses amber styling to distinguish it from active projects
- Removed the contact form component that was previously imported but not used on this page

https://claude.ai/code/session_01TbSuZTH1RPXh4SvQwrZJbM