### PR TITLE
Add Giscus comments to blog posts

### DIFF
--- a/src/components/giscus.astro
+++ b/src/components/giscus.astro
@@ -1,0 +1,17 @@
+<div class="giscus mx-auto max-w-3xl mt-12"></div>
+<script
+  src="https://giscus.app/client.js"
+  data-repo="timgent/timgent.github.io"
+  data-repo-id="REPO_ID_HERE"
+  data-category="Blog Comments"
+  data-category-id="CATEGORY_ID_HERE"
+  data-mapping="pathname"
+  data-strict="0"
+  data-reactions-enabled="1"
+  data-emit-metadata="0"
+  data-input-position="bottom"
+  data-theme="preferred_color_scheme"
+  data-lang="en"
+  crossorigin="anonymous"
+  async
+></script>

--- a/src/components/giscus.astro
+++ b/src/components/giscus.astro
@@ -2,16 +2,17 @@
 <script
   src="https://giscus.app/client.js"
   data-repo="timgent/timgent.github.io"
-  data-repo-id="REPO_ID_HERE"
+  data-repo-id="R_kgDOLfVa9w"
   data-category="Blog Comments"
-  data-category-id="CATEGORY_ID_HERE"
+  data-category-id="DIC_kwDOLfVa984C62m4"
   data-mapping="pathname"
-  data-strict="0"
+  data-strict="1"
   data-reactions-enabled="1"
-  data-emit-metadata="0"
-  data-input-position="bottom"
+  data-emit-metadata="1"
+  data-input-position="top"
   data-theme="preferred_color_scheme"
   data-lang="en"
+  data-loading="lazy"
   crossorigin="anonymous"
   async
 ></script>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from "astro:content";
 import Layout from "@layouts/Layout.astro";
 import Container from "@components/container.astro";
+import Giscus from "@components/giscus.astro";
 
 // Generate a new path for every collection entry
 export async function getStaticPaths() {
@@ -51,6 +52,7 @@ const { Content } = await render(entry);
     <div class="mx-auto prose prose-lg mt-6 max-w-3xl">
       <Content />
     </div>
+    <Giscus />
     <div class="text-center mt-8">
       <a
         href="/blog"


### PR DESCRIPTION
## Summary
This PR adds Giscus, a GitHub-powered comments system, to blog post pages, enabling readers to leave comments and reactions on individual blog posts.

## Changes
- **New component**: Created `src/components/giscus.astro` - A reusable Giscus comments widget component configured to use GitHub Discussions for storing comments
- **Blog integration**: Updated `src/pages/blog/[slug].astro` to import and render the Giscus component below blog post content

## Implementation Details
- Giscus is configured to map comments by pathname, ensuring each blog post has its own discussion thread
- The component is styled with Tailwind CSS utilities (`mx-auto max-w-3xl mt-12`) to match the blog post layout
- Configuration includes:
  - GitHub repo: `timgent/timgent.github.io`
  - Category: "Blog Comments" for organized discussions
  - Theme: Uses preferred color scheme for dark/light mode support
  - Lazy loading enabled for performance
  - Reactions and metadata enabled for enhanced engagement

https://claude.ai/code/session_01Q8E9oLLTWqgKNmsLD8WbQV