### PR TITLE
Fix Giscus comment theme clashing with white page background

### DIFF
--- a/src/components/giscus.astro
+++ b/src/components/giscus.astro
@@ -10,7 +10,7 @@
   data-reactions-enabled="1"
   data-emit-metadata="1"
   data-input-position="top"
-  data-theme="preferred_color_scheme"
+  data-theme="light"
   data-lang="en"
   data-loading="lazy"
   crossorigin="anonymous"


### PR DESCRIPTION
Switch from preferred_color_scheme to light so the comments widget
always matches the site's light theme instead of going dark when the
user's OS is in dark mode.

https://claude.ai/code/session_011YnXaeB37RKBZaJaE272QY