### PR TITLE
Fix broken data-flare card layout caused by nested anchor tags

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -20,17 +20,17 @@ import Layout from "@layouts/Layout.astro";
         </a>
       </li>
       <li class="w-full sm:w-1/2 md:w-1/3">
-        <a href="https://tim-gent.com/data-flare" class="block bg-gray-100 rounded-md p-5 h-full cursor-pointer transition-all duration-200 hover:bg-white hover:shadow-lg hover:-translate-y-1 hover:ring-2 hover:ring-indigo-300 focus-visible:outline-none focus-visible:bg-white focus-visible:shadow-lg focus-visible:-translate-y-1 focus-visible:ring-2 focus-visible:ring-indigo-300 group">
+        <div class="bg-gray-100 rounded-md p-5 h-full transition-all duration-200 hover:bg-white hover:shadow-lg hover:-translate-y-1 hover:ring-2 hover:ring-indigo-300 group">
           <div class="flex items-start justify-between gap-2">
-            <p class="font-bold text-lg group-hover:text-indigo-600 group-focus-visible:text-indigo-600 transition-colors duration-200">data-flare</p>
+            <p class="font-bold text-lg group-hover:text-indigo-600 transition-colors duration-200">data-flare</p>
             <span class="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full whitespace-nowrap mt-1">Not actively maintained</span>
           </div>
           <p class="text-sm mt-1">A Scala library for data quality testing — define checks on your Spark datasets and get clear, actionable results.</p>
           <div class="flex gap-3 mt-3">
-            <span class="text-xs text-indigo-500">Docs →</span>
-            <a href="https://github.com/timgent/data-flare" class="text-xs text-indigo-500 hover:text-indigo-700 transition-colors duration-200" onclick="event.stopPropagation()">GitHub →</a>
+            <a href="https://tim-gent.com/data-flare" class="text-xs text-indigo-500 hover:text-indigo-700 transition-colors duration-200">Docs →</a>
+            <a href="https://github.com/timgent/data-flare" class="text-xs text-indigo-500 hover:text-indigo-700 transition-colors duration-200">GitHub →</a>
           </div>
-        </a>
+        </div>
       </li>
     </ul>
   </Container>


### PR DESCRIPTION
Nested <a> tags are invalid HTML — the browser ejected the GitHub link
outside the card entirely. Changed the outer wrapper to a <div> and
made both Docs and GitHub proper standalone links inside the card.

https://claude.ai/code/session_01Rucuftsi3Pcv6TKWmAqmQL