### PR TITLE
Make data-flare card fully clickable via CSS stretched-link technique

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -20,13 +20,13 @@ import Layout from "@layouts/Layout.astro";
         </a>
       </li>
       <li class="w-full sm:w-1/2 md:w-1/3">
-        <div class="bg-gray-100 rounded-md p-5 h-full transition-all duration-200 hover:bg-white hover:shadow-lg hover:-translate-y-1 hover:ring-2 hover:ring-indigo-300 group">
-          <div class="flex items-start justify-between gap-2">
-            <p class="font-bold text-lg group-hover:text-indigo-600 transition-colors duration-200">data-flare</p>
+        <div class="relative overflow-hidden bg-gray-100 rounded-md p-5 h-full transition-all duration-200 hover:bg-white hover:shadow-lg hover:-translate-y-1 hover:ring-2 hover:ring-indigo-300 focus-within:bg-white focus-within:shadow-lg focus-within:-translate-y-1 focus-within:ring-2 focus-within:ring-indigo-300 group">
+          <div class="relative z-10 flex items-start justify-between gap-2">
+            <a href="https://tim-gent.com/data-flare" class="font-bold text-lg group-hover:text-indigo-600 group-focus-within:text-indigo-600 transition-colors duration-200 focus-visible:outline-none after:absolute after:inset-0 after:rounded-md after:content-['']">data-flare</a>
             <span class="text-xs bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full whitespace-nowrap mt-1">Not actively maintained</span>
           </div>
           <p class="text-sm mt-1">A Scala library for data quality testing — define checks on your Spark datasets and get clear, actionable results.</p>
-          <div class="flex gap-3 mt-3">
+          <div class="relative z-10 flex gap-3 mt-3">
             <a href="https://tim-gent.com/data-flare" class="text-xs text-indigo-500 hover:text-indigo-700 transition-colors duration-200">Docs →</a>
             <a href="https://github.com/timgent/data-flare" class="text-xs text-indigo-500 hover:text-indigo-700 transition-colors duration-200">GitHub →</a>
           </div>


### PR DESCRIPTION
Title <a> gets an ::after overlay (after:absolute after:inset-0) that covers the whole card, so any click on the card body navigates to the project page. Badge and nested links are raised above it with relative z-10 so they remain independently clickable. Card gets focus-within: styles for keyboard focus visual feedback.

https://claude.ai/code/session_01Rucuftsi3Pcv6TKWmAqmQL