### PR TITLE
Add GoatCounter analytics integration to blog posts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# GoatCounter view counter - set to your GoatCounter account name
+# e.g. if your GoatCounter URL is https://mysite.goatcounter.com, set this to: mysite
+PUBLIC_GOATCOUNTER_SITE=

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -16,6 +16,10 @@ export async function getStaticPaths() {
 // Get the entry directly from the prop on render
 const { entry } = Astro.props;
 const { Content } = await render(entry);
+const goatCounterSite = import.meta.env.PUBLIC_GOATCOUNTER_SITE;
+const goatCounterUrl = goatCounterSite
+  ? `https://${goatCounterSite}.goatcounter.com/count`
+  : null;
 ---
 
 <Layout title={entry.data.title}>
@@ -46,6 +50,14 @@ const { Content } = await render(entry);
             ))
           }
         </div>
+        {goatCounterUrl && (
+          <>
+            <span class="text-gray-400 hidden md:block">•</span>
+            <span class="text-gray-400 text-sm">
+              <span class="goatcounter-count" data-path={Astro.url.pathname}></span> views
+            </span>
+          </>
+        )}
       </div>
     </div>
 
@@ -61,4 +73,12 @@ const { Content } = await render(entry);
       >
     </div>
   </Container>
+  {goatCounterUrl && (
+    <script
+      is:inline
+      data-goatcounter={goatCounterUrl}
+      async
+      src="//gc.zgo.at/count.js"
+    ></script>
+  )}
 </Layout>


### PR DESCRIPTION
## Summary
Integrates GoatCounter analytics to track page views on individual blog posts. The integration is optional and only enabled when a GoatCounter site is configured.

## Key Changes
- Added GoatCounter environment variable configuration (`PUBLIC_GOATCOUNTER_SITE`) with example documentation
- Integrated GoatCounter tracking script that loads conditionally when configured
- Added view count display on blog post pages showing the number of views
- View counter displays inline with post metadata (date, reading time, etc.) with responsive styling

## Implementation Details
- GoatCounter site configuration is read from `PUBLIC_GOATCOUNTER_SITE` environment variable
- The tracking script (`//gc.zgo.at/count.js`) is loaded asynchronously only when a GoatCounter site is configured
- View count is displayed using GoatCounter's `goatcounter-count` element with the current page path
- UI includes a visual separator (bullet point) on medium screens and larger, with the view count in smaller gray text
- The implementation is non-intrusive and gracefully degrades when GoatCounter is not configured

https://claude.ai/code/session_01WAhxkejjsLoRXS9XrQJw63