### PR TITLE
Fix Pages deploy: approve esbuild/sharp build scripts for pnpm

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - sharp


### PR DESCRIPTION
## Problem

The GitHub Pages deploy that runs on every push to `main` has been **failing at the build step**, so the live site was no longer being rebuilt. The Secondary School Map project card (merged in #24) never appeared on https://tim-gent.com/projects/ as a result.

The failure is at `pnpm install`:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.7, sharp@0.33.5, sharp@0.34.5
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

Recent pnpm versions refuse to run dependency build scripts unless they're explicitly approved, and exit non-zero. This would break *any* deploy — it's unrelated to the school-map content change.

## Fix

Add a `pnpm-workspace.yaml` declaring `esbuild` and `sharp` as approved builds via `onlyBuiltDependencies`, so `pnpm install` runs their postinstall/build steps and the Astro build succeeds.

## Verification

Locally with pnpm 11:
- `pnpm install` — completes, running esbuild + sharp build scripts
- `pnpm build` — succeeds, 12 pages built
- Built `dist/projects/index.html` contains all three cards: Pack Me Up, Secondary School Map, and data-flare

Once merged, the Pages deploy will run and the new project card will go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xis5QrcAeoUfzwJ63vLk91)_