### PR TITLE
Fix Pages deploy: use allowBuilds to approve esbuild/sharp build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## Problem

The Pages deploy is still failing at `pnpm install`, even after #25:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.7, sharp@0.33.5, sharp@0.34.5
Error: Process completed with exit code 1.
```

#25 added an `onlyBuiltDependencies` key, but the pnpm version used by `withastro/action` (**pnpm 11.10.0**) does not honor that key in this setup — it reads build-script approvals from an **`allowBuilds`** map in `pnpm-workspace.yaml` instead. So the ignored-builds error persisted and the deploy kept exiting 1 (confirmed in the failed run for the #25 merge commit).

## Fix

Replace the `onlyBuiltDependencies` list with the `allowBuilds` map that this pnpm version actually consumes:

```yaml
allowBuilds:
  esbuild: true
  sharp: true
```

## Verification

Reproduced the failure and the fix locally with the same pnpm 11.10.0:
- With `onlyBuiltDependencies` only → `pnpm install` still errors with `ERR_PNPM_IGNORED_BUILDS`.
- With `allowBuilds` (this PR) + a clean `node_modules` → `pnpm install` completes and runs the esbuild/sharp build scripts, then `pnpm build` succeeds (12 pages), with the Secondary School Map card present in `dist/projects/index.html`.

Once merged, the Pages deploy should finally go green and the new project card will appear on https://tim-gent.com/projects/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xis5QrcAeoUfzwJ63vLk91)_