### PR TITLE
Fix projects page layout to be responsive

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -11,22 +11,22 @@ import Layout from "@layouts/Layout.astro";
       <Fragment slot="desc">Apps, libraries, and tools built by me</Fragment>
     </Sectionhead>
 
-    <ul class="flex flex-wrap m-5 gap-4">
-      <li class="w-full sm:w-1/2 md:w-1/3">
+    <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 m-5 gap-4">
+      <li>
         <a href="https://packmeup.tim-gent.com" class="block bg-gray-100 rounded-md p-5 h-full cursor-pointer transition-all duration-200 hover:bg-white hover:shadow-lg hover:-translate-y-1 hover:ring-2 hover:ring-indigo-300 focus-visible:outline-none focus-visible:bg-white focus-visible:shadow-lg focus-visible:-translate-y-1 focus-visible:ring-2 focus-visible:ring-indigo-300 group">
           <p class="font-bold text-lg group-hover:text-indigo-600 group-focus-visible:text-indigo-600 transition-colors duration-200">Pack Me Up</p>
           <p class="text-sm mt-1">Answer a few questions about your holiday and get a perfect packing list generated</p>
           <p class="text-xs text-indigo-500 mt-3 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-200">Visit app →</p>
         </a>
       </li>
-      <li class="w-full sm:w-1/2 md:w-1/3">
+      <li>
         <a href="https://tim-gent.com/secondary-school-map/" class="block bg-gray-100 rounded-md p-5 h-full cursor-pointer transition-all duration-200 hover:bg-white hover:shadow-lg hover:-translate-y-1 hover:ring-2 hover:ring-indigo-300 focus-visible:outline-none focus-visible:bg-white focus-visible:shadow-lg focus-visible:-translate-y-1 focus-visible:ring-2 focus-visible:ring-indigo-300 group">
           <p class="font-bold text-lg group-hover:text-indigo-600 group-focus-visible:text-indigo-600 transition-colors duration-200">Secondary School Map</p>
           <p class="text-sm mt-1">Explore secondary schools on an interactive map to help find the right one near you</p>
           <p class="text-xs text-indigo-500 mt-3 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-200">Visit app →</p>
         </a>
       </li>
-      <li class="w-full sm:w-1/2 md:w-1/3">
+      <li>
         <div class="relative overflow-hidden bg-gray-100 rounded-md p-5 h-full transition-all duration-200 hover:bg-white hover:shadow-lg hover:-translate-y-1 hover:ring-2 hover:ring-indigo-300 focus-within:bg-white focus-within:shadow-lg focus-within:-translate-y-1 focus-within:ring-2 focus-within:ring-indigo-300 group">
           <div class="relative z-10 flex items-start justify-between gap-2">
             <a href="https://tim-gent.com/data-flare" class="font-bold text-lg group-hover:text-indigo-600 group-focus-within:text-indigo-600 transition-colors duration-200 focus-visible:outline-none after:absolute after:inset-0 after:rounded-md after:content-['']">data-flare</a>


### PR DESCRIPTION
## Problem

On the projects page the cards rendered in a lopsided "2 then 1" layout instead of an even row. The container used `flex flex-wrap` with `w-1/3` card widths **plus** a `gap-4`. Flexbox width percentages don't subtract the gap, so three 33.3% cards + two gaps overflowed 100% and the third card wrapped onto a second row, while the two top cards stretched unevenly wide.

## Fix

Switch the card list from flex-wrap to a CSS grid:

```
grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4
```

Grid sizes its tracks after accounting for gaps, so the columns always fit, and the default `align-items: stretch` gives each row equal-height cards. The per-item width utilities (`w-full sm:w-1/2 md:w-1/3`) are removed since the grid now controls column count.

## Verification

Rendered the built page in a headless browser at three widths:
- **Mobile (375px):** single column, cards stack, badge and nav intact
- **Tablet (720px):** 2 columns
- **Desktop (1200px):** 3 columns in one even, equal-height row

`pnpm build` succeeds and the Secondary School Map card is present in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xis5QrcAeoUfzwJ63vLk91)_